### PR TITLE
Add 'SetGoal' tool to allowed tools in VisualizationFrame initialization

### DIFF
--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -374,7 +374,7 @@ void VisualizationFrame::initialize(const QString& display_config_file)
   splash_ = nullptr;
 
   // --- Keep only Interact, Move Camera, and Measure tools ---
-  QStringList allowed_tools = {"rviz/Interact", "rviz/MoveCamera", "rviz/Measure"};
+  QStringList allowed_tools = {"rviz/Interact", "rviz/MoveCamera", "rviz/Measure", "rviz/SetGoal"};
 
   for (int i = tool_man->numTools() - 1; i >= 0; --i)
   {


### PR DESCRIPTION
This pull request adds a new tool, `rviz/SetGoal`, to the list of allowed tools in the `VisualizationFrame` initialization process. This change enhances the functionality by enabling users to set navigation goals directly within RViz.

Key change:

* [`src/rviz/visualization_frame.cpp`](diffhunk://#diff-1730999a1db3221d79d7f9e8443faf7882433a9ea0edd310ada6c7b2e23a5fd7L377-R377): Updated the `allowed_tools` list in `VisualizationFrame::initialize` to include `rviz/SetGoal`, allowing users to set navigation goals in RViz.